### PR TITLE
World generation freeze fixed.

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/api/TreeHelper.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/api/TreeHelper.java
@@ -138,14 +138,14 @@ public class TreeHelper {
 		}
 		return false;
 	}
-	
+
+	@Deprecated
 	public static BlockPos findGround(World world, BlockPos pos) {
 		//Rise up until we are no longer in a solid block
-		while(world.getBlockState(pos).isFullCube()) {
+		while(world.getBlockState(pos).isOpaqueCube()) {
 			pos = pos.up();
 		}
-		//Dive down until we are again
-		while(!world.getBlockState(pos).isFullCube() && pos.getY() > 50) {
+		while(!world.getBlockState(pos).isOpaqueCube() && pos.getY() > 50) {
 			pos = pos.down();
 		}
 		return pos;

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/TreeGenerator.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/TreeGenerator.java
@@ -27,7 +27,7 @@ import net.minecraftforge.common.BiomeDictionary.Type;
 public class TreeGenerator implements IWorldGenerator {
 	
 	private static TreeGenerator INSTANCE;
-	
+
 	public BiomeTreeHandler biomeTreeHandler; //Provides forest properties for a biome
 	public BiomeRadiusCoordinator radiusCoordinator; //Finds radius for coordinates
 	public TreeCodeStore codeStore;
@@ -137,8 +137,7 @@ public class TreeGenerator implements IWorldGenerator {
 			for (int zi = 0; zi < 4; ++zi) {
 				int posX = pos.getX() + xi * 4 + 1 + 8 + random.nextInt(3);
 				int posZ = pos.getZ() + zi * 4 + 1 + 8 + random.nextInt(3);
-				BlockPos blockpos = world.getHeight(pos.add(posX, 0, posZ));
-				blockpos = TreeHelper.findGround(world, blockpos).up();
+				BlockPos blockpos = world.getHeight(pos);
 				
 				if (random.nextInt(6) == 0) {
 					new WorldGenBigMushroom().generate(world.real(), random, blockpos.getX(), blockpos.getY(), blockpos.getZ());


### PR DESCRIPTION
World generation freeze caused by roofed forest while loop fixed.

Regarding issue: #129 

As I checked, the cause of the freeze was while loop in the findGround method. I don't know what isFullCube should return, but it keeps returning the same value even it is air or out of 256 height limit. So, I changed it to isOpaqueCube, which should work the same as there is no block transparent on the ground.

Still, you can simply get heightmap and use that to generate trees. Because of that reason, I didn't use findGround function in roofedForestCompensation method and set it deprecated as it was referenced in another class.

Another issue was multiplying x and z values by adding them already set location, which caused mushroom's spawn at locations multiplied by 2.