### PR TITLE
Increased vine converage on jungle and swamp trees

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/trees/TreeJungle.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/trees/TreeJungle.java
@@ -44,7 +44,7 @@ public class TreeJungle extends TreeFamilyVanilla {
 			
 			//Add species features
 			addGenFeature(new FeatureGenCocoa());
-			addGenFeature(new FeatureGenVine());
+			addGenFeature(new FeatureGenVine().setQuantity(16).setMaxLength(16));
 			addGenFeature(new FeatureGenUndergrowth());
 		}
 		

--- a/src/main/java/com/ferreusveritas/dynamictrees/trees/TreeOak.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/trees/TreeOak.java
@@ -91,7 +91,7 @@ public class TreeOak extends TreeFamilyVanilla {
 			setupStandardSeedDropping();
 			
 			//Add species features
-			addGenFeature(new FeatureGenVine().setMaxLength(7).setVerSpread(30).setRayDistance(6).setQuantity(5));//Generate Vines
+			addGenFeature(new FeatureGenVine().setMaxLength(7).setVerSpread(30).setRayDistance(6).setQuantity(24));//Generate Vines
 		}
 		
 		@Override


### PR DESCRIPTION
DT's Jungle and swamp trees always felt pretty lacking in their vine amounts/lengths, mostly due to the size increase in leaf canopies, so this is just a simple change to help improve that.

Screenshots of what they look like with it changed:

![](https://i.imgur.com/4qnWDjc.jpg)

![](https://i.imgur.com/7XDtkhR.jpg)