### PR TITLE
fix duplication of RenderGlobalWrapper

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/event/BlockBreakAnimationClientHandler.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/event/BlockBreakAnimationClientHandler.java
@@ -45,6 +45,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -65,7 +66,10 @@ public class BlockBreakAnimationClientHandler implements IResourceManagerReloadL
 		if (event.getEntity() instanceof EntityPlayerSP && Minecraft.getMinecraft().player != null) {
 			if (Minecraft.getMinecraft().player.getEntityId() == event.getEntity().getEntityId()) {
 				event.getWorld().removeEventListener(Minecraft.getMinecraft().renderGlobal);
-				event.getWorld().addEventListener(new RenderGlobalWrapper(event.getWorld()));
+				List<IWorldEventListener> listeners = ReflectionHelper.getPrivateValue(World.class, event.getWorld(), "eventListeners", "field_73021_x");
+				if (listeners.stream().noneMatch((el) -> el instanceof RenderGlobalWrapper)) {
+					event.getWorld().addEventListener(new RenderGlobalWrapper(event.getWorld()));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Small fix to prevent duplicate RenderGlobalWrapper instances from being added to the listener list when a player changes dimension. This was causing issues such as duplication of sounds and particles. I tested this in a deobfuscated development environment, and under an obfuscated instance running Forge 2808. It seems to fix the issue.

It works by checking to make sure an instance of RenderGlobalWrapper does not exist in the eventListeners list, which it accesses by reflection. As such, both a deobf name and an obf name will be needed to be maintained in future versions. Alternative solutions may be to maintain a set of worlds that the listener has already been applied to and skipping if it has already been added.

Additionally, my implementation of the fix uses a lambda, which may not be desired in order to support older JRE versions.

Thank you for your consideration!