### PR TITLE
Config for disabling the Dirt Bucket's ability to place Dirt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ minecraft {
 }
 
 dependencies {
-    compile "mcp.mobius.waila:Hwyla:+"
+    compile "mcp.mobius.waila:Hwyla:1.8.26-B41_1.12.2"
 }
 
 processResources {

--- a/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
@@ -84,6 +84,7 @@ public class ModConfigs {
 		enableFallingTrees = config.getBoolean("enableFallingTrees", "interaction", true, "If enabled then trees will fall over when harvested");
 		enableFallingTreeDamage = config.getBoolean("enableFallingTreeDamage", "interaction", true, "If enabled then trees will harm living entities when falling");
 		fallingTreeDamageMultiplier = config.getFloat("fallingTreeDamageMultiplier", "interaction", 1.0f, 0.0f, 100.0f, "Multiplier for damage incurred by a falling tree");
+		dirtBucketPlacesDirt = config.getBoolean("dirtBucketPlacesDirt", "interaction", true, "If enabled the Dirt Bucket will place a dirt block on right-click");
 		
 		//Vanilla
 		replaceVanillaSapling = config.getBoolean("replaceVanillaSapling", "vanilla", false, "Right clicking with a vanilla sapling places a dynamic sapling instead.");

--- a/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
@@ -37,7 +37,7 @@ public class ModConfigs {
 	public static boolean enableFallingTrees;
 	public static boolean enableFallingTreeDamage;
 	public static float fallingTreeDamageMultiplier;
-	
+	public static boolean dirtBucketPlacesDirt;
 	public static boolean replaceVanillaSapling;
 	
 	public static boolean podzolGen;

--- a/src/main/java/com/ferreusveritas/dynamictrees/items/DirtBucket.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/items/DirtBucket.java
@@ -3,6 +3,7 @@ package com.ferreusveritas.dynamictrees.items;
 import javax.annotation.Nullable;
 
 import com.ferreusveritas.dynamictrees.ModTabs;
+import com.ferreusveritas.dynamictrees.ModConfigs;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -44,33 +45,38 @@ public class DirtBucket extends Item {
 		ItemStack itemStack = player.getHeldItem(hand);
 		RayTraceResult raytraceresult = this.rayTrace(world, player, false);
 		
-		if (raytraceresult == null) {
-			return new ActionResult(EnumActionResult.PASS, itemStack);
-		}
-		else if (raytraceresult.typeOfHit != RayTraceResult.Type.BLOCK) {
-			return new ActionResult(EnumActionResult.PASS, itemStack);
-		}
-		else {
-			BlockPos blockpos = raytraceresult.getBlockPos();
-			
-			if (!world.isBlockModifiable(player, blockpos)) {
-				return new ActionResult(EnumActionResult.FAIL, itemStack);
+		if (ModConfigs.dirtBucketPlacesDirt) {
+			if (raytraceresult == null) {
+				return new ActionResult(EnumActionResult.PASS, itemStack);
+			}
+			else if (raytraceresult.typeOfHit != RayTraceResult.Type.BLOCK) {
+				return new ActionResult(EnumActionResult.PASS, itemStack);
 			}
 			else {
-				boolean isReplacable = world.getBlockState(blockpos).getBlock().isReplaceable(world, blockpos);
-				BlockPos workingBlockPos = isReplacable && raytraceresult.sideHit == EnumFacing.UP ? blockpos : blockpos.offset(raytraceresult.sideHit);
+				BlockPos blockpos = raytraceresult.getBlockPos();
 				
-				if (!player.canPlayerEdit(workingBlockPos, raytraceresult.sideHit, itemStack)) {
+				if (!world.isBlockModifiable(player, blockpos)) {
 					return new ActionResult(EnumActionResult.FAIL, itemStack);
-				}
-				else if (this.tryPlaceContainedDirt(player, world, workingBlockPos)) {
-					player.addStat(StatList.getObjectUseStats(this));
-					return !player.capabilities.isCreativeMode ? new ActionResult(EnumActionResult.SUCCESS, new ItemStack(Items.BUCKET)) : new ActionResult(EnumActionResult.SUCCESS, itemStack);
 				}
 				else {
-					return new ActionResult(EnumActionResult.FAIL, itemStack);
+					boolean isReplacable = world.getBlockState(blockpos).getBlock().isReplaceable(world, blockpos);
+					BlockPos workingBlockPos = isReplacable && raytraceresult.sideHit == EnumFacing.UP ? blockpos : blockpos.offset(raytraceresult.sideHit);
+					
+					if (!player.canPlayerEdit(workingBlockPos, raytraceresult.sideHit, itemStack)) {
+						return new ActionResult(EnumActionResult.FAIL, itemStack);
+					}
+					else if (this.tryPlaceContainedDirt(player, world, workingBlockPos)) {
+						player.addStat(StatList.getObjectUseStats(this));
+						return !player.capabilities.isCreativeMode ? new ActionResult(EnumActionResult.SUCCESS, new ItemStack(Items.BUCKET)) : new ActionResult(EnumActionResult.SUCCESS, itemStack);
+					}
+					else {
+						return new ActionResult(EnumActionResult.FAIL, itemStack);
+					}
 				}
 			}
+		}
+		else {
+			return new ActionResult(EnumActionResult.PASS, itemStack);
 		}
 	}
 	


### PR DESCRIPTION
Added a config for disabling the Dirt Bucket's ability to place Dirt and subsequently return an empty bucket. Closes #225 

Warning: This is my first attempt at actual modding, so it's likely that I did not implement this correctly. 
I was unable to test it, because I couldn't find the version of HWYLA that gradle wanted.
