### PR TITLE
Allows compat for other Mods to break trees without a fake player

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ minecraft {
 }
 
 dependencies {
-    compile "mcp.mobius.waila:Hwyla:+"
+    compile "mcp.mobius.waila:Hwyla:1.8.26-B41_1.12.2"
 }
 
 processResources {

--- a/src/main/java/com/ferreusveritas/dynamictrees/api/IFutureBreakable.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/api/IFutureBreakable.java
@@ -1,12 +1,12 @@
 package com.ferreusveritas.dynamictrees.api;
 
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public interface IFutureBreakable {
 	
-	public void futureBreak(IBlockState state, World world, BlockPos pos, EntityPlayer player);
+	public void futureBreak(IBlockState state, World world, BlockPos pos, EntityLivingBase player);
 	
 }

--- a/src/main/java/com/ferreusveritas/dynamictrees/event/FutureBreak.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/event/FutureBreak.java
@@ -7,7 +7,7 @@ import java.util.List;
 import com.ferreusveritas.dynamictrees.api.IFutureBreakable;
 
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -18,14 +18,14 @@ public class FutureBreak {
 	public final IBlockState state;
 	public final World world;
 	public final BlockPos pos;
-	public final EntityPlayer player;
+	public final EntityLivingBase entity;
 	public int ticks = 0;
 	
-	public FutureBreak(IBlockState state, World world, BlockPos pos, EntityPlayer player, int ticks) {
+	public FutureBreak(IBlockState state, World world, BlockPos pos, EntityLivingBase entity, int ticks) {
 		this.state = state;
 		this.world = world;
 		this.pos = pos;
-		this.player = player;
+		this.entity = entity;
 		this.ticks = ticks;
 	}
 	
@@ -45,7 +45,7 @@ public class FutureBreak {
 					if(fb.state.getBlock() instanceof IFutureBreakable) {
 						if(fb.ticks-- <= 0) {
 							IFutureBreakable branch = (IFutureBreakable) fb.state.getBlock();
-							branch.futureBreak(fb.state, world, fb.pos, fb.player);
+							branch.futureBreak(fb.state, world, fb.pos, fb.entity);
 							i.remove();
 						}
 					} else {


### PR DESCRIPTION
Changes the BlockBranch class to allow for blocks to be broken via an Entity, not just an EntityPlayer (or FakePlayer)

Also fixes 1.12.2 version's build.gradle for Hwyla 