### PR TITLE
🐛 Fixed a bug with subterranean generation

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/WorldGeneratorTrees.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/WorldGeneratorTrees.java
@@ -23,19 +23,19 @@ import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraftforge.fml.common.IWorldGenerator;
 
 public class WorldGeneratorTrees implements IWorldGenerator {
-	
+
 	public static class GroundFinder implements IGroundFinder {
-		
+
 		protected boolean inNetherRange(BlockPos pos) {
 	        return pos.getY() >= 0 && pos.getY() <= 128;
 		}
-		
+
 		protected ArrayList<Integer> findSubterraneanLayerHeights(World world, BlockPos start) {
-			
+
 			MutableBlockPos pos = new MutableBlockPos(world.getHeight(start)).move(EnumFacing.DOWN);
-			
+
 			ArrayList<Integer> layers = new ArrayList();
-			
+
 			while(inNetherRange(pos)) {
 				while(!world.isAirBlock(pos) && inNetherRange(pos)) { pos.move(EnumFacing.UP, 4); } //Zip up 4 blocks at a time until we hit air
 				while(world.isAirBlock(pos) && inNetherRange(pos))  { pos.move(EnumFacing.DOWN); } //Move down 1 block at a time until we hit not-air
@@ -43,62 +43,62 @@ public class WorldGeneratorTrees implements IWorldGenerator {
 				pos.move(EnumFacing.UP, 16); //Move up 16 blocks
 				while(world.isAirBlock(pos) && inNetherRange(pos)) { pos.move(EnumFacing.UP, 4); } //Zip up 4 blocks at a time until we hit ground
 			}
-			
+
 			//Discard the last result as it's just the top of the biome(bedrock for nether)
 			if (layers.size() > 0) {
 				layers.remove(layers.size() - 1);
 			}
-			
+
 			return layers;
 		}
-		
+
 		protected BlockPos findSubterraneanGround(World world, BlockPos start) {
 			ArrayList<Integer> layers = findSubterraneanLayerHeights(world, start);
 			if (layers.size() < 1) {
 				return BlockPos.ORIGIN;
 			}
 			int y = layers.get(world.rand.nextInt(layers.size()));
-			
-			return new BlockPos(start.getX(), y, start.getY());
+
+			return new BlockPos(start.getX(), y, start.getZ());
 		}
-		
+
 		protected boolean inOverworldRange(BlockPos pos) {
 			return pos.getY() >= 0 && pos.getY() <= 255;
 		}
-		
+
 		protected BlockPos findOverworldGround(World world, BlockPos start) {
-			
+
 			Chunk chunk = world.getChunkFromBlockCoords(start);//We'll use a chunk for the search so we don't have to keep looking up the chunk for every block
-			
+
 			MutableBlockPos mPos = new MutableBlockPos(world.getHeight(start)).move(EnumFacing.UP, 2);//Mutable allows us to change the test position easily
 			while(inOverworldRange(mPos)) {
-				
+
 				IBlockState state = chunk.getBlockState(mPos);
 				Block testBlock = state.getBlock();
-				
+
 				if(testBlock != Blocks.AIR) {
 					Material material = state.getMaterial();
 					if( material == Material.GROUND || material == Material.WATER || //These will account for > 90% of blocks in the world so we can solve this early
 							(state.getMaterial().blocksMovement() &&
 							!testBlock.isLeaves(state, world, mPos) &&
 							!testBlock.isFoliage(world, mPos))) {
-						return mPos.toImmutable(); 
+						return mPos.toImmutable();
 					}
 				}
-				
+
 				mPos.move(EnumFacing.DOWN);
 			}
-			
+
 			return BlockPos.ORIGIN;
 		}
-		
+
 		@Override
 		public BlockPos findGround(BiomeEntry biomeEntry, World world, BlockPos start) {
 			return biomeEntry.isSubterraneanBiome() ? findSubterraneanGround(world, start) : findOverworldGround(world, start);
 		}
-		
+
 	}
-	
+
 	@Override
 	public void generate(Random randomUnused, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
 		if(world.getWorldType() == WorldType.FLAT) {
@@ -111,5 +111,5 @@ public class WorldGeneratorTrees implements IWorldGenerator {
 			treeGenerator.getCircleProvider().getPoissonDiscs(world, chunkX, 0, chunkZ).forEach(c -> treeGenerator.makeTree(world, dbase, c, new GroundFinder(), safeBounds));
 		}
 	}
-	
+
 }


### PR DESCRIPTION
Subterranean gen used pos.getY() in the Z coordinate when determing the generation location, causing all trees to generate along Z = 0.  Swapped with the correct coordinate.