### PR TITLE
Fixed ArithmeticException in TextureUtils

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/client/TextureUtils.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/client/TextureUtils.java
@@ -188,9 +188,24 @@ public class TextureUtils {
 			}
 		}
 		
-		int r = (int) (rAccum / count);
-		int g = (int) (gAccum / count);
-		int b = (int) (bAccum / count);
+		int r;
+		int g;
+		int b;
+		try {
+		    r = (int) (rAccum / count);
+		} catch (ArithmeticException e) {
+			r = 0;
+		}
+		try {
+			g = (int) (gAccum / count);	
+		} catch (ArithmeticException e) {
+			g = 0;
+		}
+		try {
+			b = (int) (bAccum / count);
+		} catch (ArithmeticException e) {
+			b = 0;
+		}
 		
 		return compose(r, g, b, 255);
 	}


### PR DESCRIPTION
Simply added a try catch to see if a 0 division is done. Trees and everything still generate and look fine after making this change.

Fixes #290 