### PR TITLE
Solves StackOverflow in BlockBranch.java. Fixes #327 #330

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
@@ -28,6 +28,7 @@ public class ModConfigs {
 	public static int maxBranchRotRadius;
 	public static boolean enableAppleTrees;
 	public static boolean enableThickTrees;
+	public static boolean enableOverflowFix;
 
 	public static boolean isLeavesPassable;
 	public static boolean vanillaLeavesCollision;
@@ -74,6 +75,7 @@ public class ModConfigs {
 		maxBranchRotRadius = config.getInt("maxBranchRotRadius", "trees", 8, 0, 24, "The maximum radius of a branch that is allowed to rot away. 8 = Full block size.  Set to 0 to prevent rotting");
 		enableAppleTrees = config.getBoolean("enableAppleTrees", "trees", true, "If enabled apple trees will be generated during worldgen and oak trees will not drop apples");
 		enableThickTrees = config.getBoolean("enableThickTrees", "trees", true, "If enabled then certain species trunks will be able to grow wider than a single block");
+		enableOverflowFix = config.getBoolean("enableOverflowFix", "trees", false, "If enabled removes normal breaking recursion for branches destroyed by fire, enable if you encounter StackOverflow from firetick");
 		
 		//Interaction
 		isLeavesPassable = config.getBoolean("isLeavesPassable", "interaction", false, "If enabled all leaves will be passable");

--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockBranch.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockBranch.java
@@ -533,7 +533,11 @@ public abstract class BlockBranch extends Block implements ITreePart, IFutureBre
 			} else
 			if(toBlock == Blocks.FIRE) { //Block has burned
 				world.setBlockState(pos, state, 0);//Set the block back and attempt a proper breaking
-				sloppyBreak(world, pos, DestroyType.VOID);
+				if(ModConfigs.enableOverflowFix) {//Config option to disable recursion in event of Stackoverflow issues
+					sloppyBreak(world, pos, DestroyType.VOID);
+				} else {
+					sloppyBreak(world, pos, DestroyType.FIRE);
+					world.setBlockState(pos, Blocks.FIRE.getDefaultState()); }
 			} else
 			if(toBlock == Blocks.STONE) { //Likely destroyed by the Pyroclasm mod's volcanic lava
 				world.setBlockState(pos, state, 0);//Set the block back and attempt a proper breaking

--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockBranch.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockBranch.java
@@ -533,8 +533,7 @@ public abstract class BlockBranch extends Block implements ITreePart, IFutureBre
 			} else
 			if(toBlock == Blocks.FIRE) { //Block has burned
 				world.setBlockState(pos, state, 0);//Set the block back and attempt a proper breaking
-				sloppyBreak(world, pos, DestroyType.FIRE);
-				world.setBlockState(pos, Blocks.FIRE.getDefaultState());
+				sloppyBreak(world, pos, DestroyType.VOID);
 			} else
 			if(toBlock == Blocks.STONE) { //Likely destroyed by the Pyroclasm mod's volcanic lava
 				world.setBlockState(pos, state, 0);//Set the block back and attempt a proper breaking


### PR DESCRIPTION
Modifies sloppy block breaking by fire to void the branch rather than attempting to re-break the branch, which can cause recursion into a stack overflow in certain situations.
I am no coder and am sure there is a more elegant solution to this, however, I have compiled with this edit and tested it on known-issue-worlds and it does both prevent and fixes the stackoverflow errors.
One known side effect of this edit is that it causes branches broken by fire to skip their falling animation, which helps FPS when near a large forest fire.