### PR TITLE
Fix leaves destruction problem

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/api/backport/BlockPos.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/api/backport/BlockPos.java
@@ -188,5 +188,9 @@ public class BlockPos implements Comparable<BlockPos> {
         double d2 = (double)this.getZ() - toZ;
         return d0 * d0 + d1 * d1 + d2 * d2;
     }
+
+	public static Iterable<BlockPos> getAllInBox(int i, int j, int k, int l, int m, int n) {
+		return getAllInBox(new BlockPos(i, j, k), new BlockPos(l, m, n));
+	}
     
 }

--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockRootyDirt.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockRootyDirt.java
@@ -156,7 +156,7 @@ public class BlockRootyDirt extends BlockBackport implements ITreePart {
 	public void destroyTree(World world, BlockPos pos) {
 		BlockBranch branch = TreeHelper.getBranch(world, pos.up());
 		if(branch != null) {
-			branch.destroyEntireTree(world, pos.up());
+			branch.destroyBranchFromNode(world, pos.up(), true);
 		}
 	}
 	

--- a/src/main/java/com/ferreusveritas/dynamictrees/inspectors/NodeDestroyer.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/inspectors/NodeDestroyer.java
@@ -1,6 +1,7 @@
 package com.ferreusveritas.dynamictrees.inspectors;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
 import com.ferreusveritas.dynamictrees.api.backport.BlockPos;
@@ -23,9 +24,15 @@ import net.minecraft.item.ItemStack;
 public class NodeDestroyer implements INodeInspector {
 
 	Species species;//Destroy any node that's made of the same kind of wood
+	private List<BlockPos> endPoints;//We always need to track endpoints during destruction
 
 	public NodeDestroyer(Species species) {
+		this.endPoints = new ArrayList<BlockPos>(32);
 		this.species = species;
+	}
+
+	public List<BlockPos> getEnds() {
+		return endPoints;
 	}
 
 	@Override
@@ -34,7 +41,7 @@ public class NodeDestroyer implements INodeInspector {
 
 		if(branch != null && species.getTree() == branch.getTree()) {
 			if(branch.getRadius(world, pos) == 1) {
-				killSurroundingLeaves(world, pos);//Destroy the surrounding leaves
+				endPoints.add(pos);
 			}
 			world.setBlockToAir(pos);//Destroy the branch
 		}

--- a/src/main/java/com/ferreusveritas/dynamictrees/util/SimpleVoxmap.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/util/SimpleVoxmap.java
@@ -160,7 +160,7 @@ public class SimpleVoxmap {
 		z += center.getZ();
 		if(testBounds(x, y, z)) {
 			if(value != 0) {
-				setYTouched(y);
+				setYTouched(y - center.getY());
 			}
 			data[calcPos(x, y, z)] = value;
 		}


### PR DESCRIPTION
Backport of https://github.com/ferreusveritas/DynamicTrees/commit/a51653afe27b151475f88f7f6f7e8a0aeabdaad9 and https://github.com/ferreusveritas/DynamicTrees/commit/84102a77aab5908b0b91681679f6a7860368934d.

This fixes the issue where breaking a small branch destroys a lot of leaves that are unrelated.
Since the 1.7.10 version doesn't receive fixes anymore, I backported the fix myself, since I find that bug pretty annoying.
Would you mind reviewing and merging this?