### PR TITLE
Override getItem in BlockDynamicLeaves to return primitive leaves

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/ModConfigs.java
@@ -28,7 +28,6 @@ public class ModConfigs {
 	public static float diseaseChance;
 	public static int maxBranchRotRadius;
 	public static boolean enableAppleTrees;
-	public static boolean enableThickTrees;
 
 	public static boolean isLeavesPassable;
 	public static boolean vanillaLeavesCollision;

--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockDynamicLeaves.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockDynamicLeaves.java
@@ -81,7 +81,12 @@ public class BlockDynamicLeaves extends BlockLeaves implements ITreePart, IAgeab
 		setUnlocalizedName(getRegistryName().toString());
 		return this;
 	}
-	
+
+	@Override
+	public ItemStack getItem(World worldIn, BlockPos pos, IBlockState state) {
+		return getProperties(state).getPrimitiveLeavesItemStack();
+	}
+
 	@Override
 	protected BlockStateContainer createBlockState() {
 		return new BlockStateContainer(this, new IProperty[] {HYDRO, TREE, DECAYABLE});
@@ -211,11 +216,6 @@ public class BlockDynamicLeaves extends BlockLeaves implements ITreePart, IAgeab
 	
 	protected static interface NewLeavesPropertiesHandler {
 		IBlockState getLeaves(World world, BlockPos pos, IBlockState leavesStateWithHydro);
-	}
-	
-	@Override
-	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
-		return getProperties(state).getPrimitiveLeavesItemStack();
 	}
 	
 	@Override


### PR DESCRIPTION
Changes `BlockDynamicLeaves` class to override `getItem` and return the primitive leaves stack. Originally created to (partially) solve #455, but may also make for other compatibility where other mods use this method on blocks. 

However, it needs some more testing done to ensure it doesn’t break anything. 