### PR TITLE
Barretone bot fix: see #478

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockTrunkShell.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockTrunkShell.java
@@ -114,6 +114,12 @@ public class BlockTrunkShell extends Block {
 	
 	@Override
 	public float getBlockHardness(IBlockState blockState, World world, BlockPos pos) {
+		// barretone fix, not calling the log's actual block and copying the value
+		// in case the getHardness somehow gets modified, since this is a fix,
+		// it's better to have a constant instead of a maybe.
+		if (world == null && pos == null) {
+			return 2.0F;
+		}
 		ShellMuse muse = getMuse(world, blockState, pos);
 		return muse != null ? muse.state.getBlock().getBlockHardness(muse.state, world, muse.pos) : 0.0f;
 	}


### PR DESCRIPTION
fixes #478
I could use the registry and get the hardness for the oak log; but since this is a fix related to baritone not sending enough data, I'm assuming a worst-case scenario where the vanilla function has been replaced with one that needs that missing data to. So I'm returning a constant so that we don't have a maybe.