### PR TITLE
Fix logs and stick stacks dropped exceeding maximum stack size

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/branches/BranchBlock.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/branches/BranchBlock.java
@@ -453,8 +453,10 @@ public abstract class BranchBlock extends BlockWithDynamicHardness implements IT
         for (ItemStack stack : primitiveLogDrops) {
             int num = numLogs * stack.getCount();
             while (num > 0) {
-                drops.add(new ItemStack(stack.getItem(), Math.min(num, 64)));
-                num -= 64;
+                ItemStack drop = stack.copy();
+                drop.setCount(Math.min(num, stack.getMaxStackSize()));
+                drops.add(drop);
+                num -= stack.getMaxStackSize();
             }
         }
         return volumeIn - numLogs;

--- a/src/main/java/com/ferreusveritas/dynamictrees/systems/dropcreators/LogDropCreator.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/systems/dropcreators/LogDropCreator.java
@@ -6,6 +6,8 @@ import com.ferreusveritas.dynamictrees.systems.dropcreators.context.LogDropConte
 import com.ferreusveritas.dynamictrees.systems.nodemappers.NetVolumeNode;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.trees.Species.LogsAndSticks;
+
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
 public class LogDropCreator extends DropCreator {
@@ -45,7 +47,13 @@ public class LogDropCreator extends DropCreator {
         }
         int numSticks = las.sticks;
         if (numSticks > 0) {
-            context.drops().add(species.getFamily().getStick(numSticks));
+            final ItemStack stack = species.getFamily().getStick(numSticks);
+            while (numSticks > 0) {
+                ItemStack drop = stack.copy();
+                drop.setCount(Math.min(numSticks, stack.getMaxStackSize()));
+                context.drops().add(drop);
+                numSticks -= stack.getMaxStackSize();
+            }
         }
     }
 

--- a/src/main/java/com/ferreusveritas/dynamictrees/systems/dropcreators/StickDropCreator.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/systems/dropcreators/StickDropCreator.java
@@ -55,10 +55,17 @@ public class StickDropCreator extends DropCreator {
             }
         }
         if (context.random().nextInt((int) (chance / configuration.get(RARITY))) == 0) {
-            final ItemStack drop = configuration.getOrInvalidDefault(STICK, stick -> stick != ItemStack.EMPTY,
-                    context.species().getSeedStack(1)).copy();
-            drop.setCount(1 + context.random().nextInt(configuration.get(MAX_COUNT)));
-            context.drops().add(drop);
+            int num = 1 + context.random().nextInt(configuration.get(MAX_COUNT));
+            if (num > 0) {
+                final ItemStack stack = configuration.getOrInvalidDefault(STICK, stick -> stick != ItemStack.EMPTY,
+                        context.species().getSeedStack(1));
+                while (num > 0) {
+                    ItemStack drop = stack.copy();
+                    drop.setCount(Math.min(num, stack.getMaxStackSize()));
+                    context.drops().add(drop);
+                    num -= stack.getMaxStackSize();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When item stacks are dropped into the world as entities that have a count larger than the maximum stack size for that item, it is possible to pick them up as-is, as long as they don't exceed the player inventory stack size maximum. That is, you can for example pick up 6 logs in a single slot in your inventory, when their maximum stack size is set to 1.

Dynamic Trees currently has a hardcoded limit for log drops of 64, and none for sticks. This is not an issue in Vanilla, but as you can imagine it is a problem when a modpack changes these values, for example using KubeJS, or if someone were to define custom trees with non-standard stack size limits.

This patch modifies the hardcoded 64 stack limit for logs that causes larger numbers to split into multiple stacks, to instead use the stack's max size. The same is introduced for stick drops.

![2021-11-08_18 13 00](https://user-images.githubusercontent.com/272586/140788865-4bfe99a5-db97-4b51-bac0-edefdf05fe68.png)

I hope I found all the relevant places to make this change.
I understand this might all change with the introduction of the new drops system - which by the way I hope will be able to drop things based on the held item, such as it having silk touch - but in the end I made this change to a custom build of the mod for use in my modpack, so I figured I'd submit this.