### PR TITLE
Move generateDirtBucketRecipes setting to common config

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/init/DTConfigs.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/init/DTConfigs.java
@@ -163,10 +163,10 @@ public class DTConfigs {
                 define("podzolGen", true);
         SERVER_BUILDER.pop();
 
-        SERVER_BUILDER.comment("Miscellaneous Settings").push("misc");
-        GENERATE_DIRT_BUCKET_RECIPES = SERVER_BUILDER.comment("If enabled, dirt bucket recipes will be automatically generated.")
+        COMMON_BUILDER.comment("Miscellaneous Settings").push("misc");
+        GENERATE_DIRT_BUCKET_RECIPES = COMMON_BUILDER.comment("If enabled, dirt bucket recipes will be automatically generated.")
                 .define("generateDirtBucketRecipes", true);
-        SERVER_BUILDER.pop();
+        COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("World Generation Settings").push("world");
         WORLD_GEN = COMMON_BUILDER.comment("World Generation produces Dynamic Trees instead of Vanilla trees.").


### PR DESCRIPTION
This moves the generateDirtBucketRecipes setting from server to common config, which is required due to an issue where the setting can't actually be loaded in time for it to actually take effect, essentially making it useless (until `/reload` is run manually). See #630 for more details.

Confirmed that a custom build fixes the issue in my modpack.