### PR TITLE
Use Aqua Acrobatics water texture when it's installed

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/models/ModelRootyWater.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/models/ModelRootyWater.java
@@ -13,6 +13,7 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.fml.common.Loader;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +26,9 @@ public class ModelRootyWater implements IBakedModel {
 
 	public ModelRootyWater(IBakedModel rootsModel) {
 		this.rootsModel = rootsModel;
-		this.stillWaterTexture = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("minecraft:blocks/water_still");
-		this.flowWaterTexture = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("minecraft:blocks/water_flow");
+		String textureProvider = Loader.isModLoaded("aquaacrobatics") ? "aquaacrobatics" : "minecraft";
+		this.stillWaterTexture = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(textureProvider + ":blocks/water_still");
+		this.flowWaterTexture = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(textureProvider + ":blocks/water_flow");
 	}
 
 	@Override


### PR DESCRIPTION
A mod I maintain, Aqua Acrobatics, implements the 1.13 water coloring system. For backwards compatibility with mods which expect the water color to be blue, it provides a blue-colored texture. However, water in the world is rendered with the `aquaacrobatics:blocks/water_xxx` textures, which are white and can thus take on any color.

This PR fixes the issue with rooty water seen here: https://github.com/Fuzss/aquaacrobatics/issues/70