### PR TITLE
Add transition sapling to tree event

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/api/event/TransitionSaplingToTreeEvent.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/api/event/TransitionSaplingToTreeEvent.java
@@ -1,0 +1,47 @@
+package com.ferreusveritas.dynamictrees.api.event;
+
+import com.ferreusveritas.dynamictrees.trees.Species;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Fired when {@link Species#transitionToTree(net.minecraft.world.World, net.minecraft.util.math.BlockPos)} is invoked,
+ * before placement checks and logic are done.
+ * <p>
+ * This event is {@link Cancelable}.
+ * <p>
+ * This event does not {@linkplain HasResult have a result}.
+ * <p>
+ * This event is fired on the {@linkplain net.minecraftforge.common.MinecraftForge#EVENT_BUS Forge bus}.
+ *
+ * @author Harley O'Connor
+ */
+@Cancelable
+public final class TransitionSaplingToTreeEvent extends Event {
+
+    /** The species to transition to. */
+    private final Species species;
+    private final World world;
+    /** Position of sapling block. */
+    private final BlockPos pos;
+
+    public TransitionSaplingToTreeEvent(Species species, World world, BlockPos pos) {
+        this.species = species;
+        this.world = world;
+        this.pos = pos;
+    }
+
+    public Species getSpecies() {
+        return species;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public BlockPos getPos() {
+        return pos;
+    }
+}

--- a/src/main/java/com/ferreusveritas/dynamictrees/trees/Species.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/trees/Species.java
@@ -6,6 +6,7 @@ import com.ferreusveritas.dynamictrees.api.TreeRegistry;
 import com.ferreusveritas.dynamictrees.api.data.Generator;
 import com.ferreusveritas.dynamictrees.api.data.SaplingStateGenerator;
 import com.ferreusveritas.dynamictrees.api.data.SeedItemModelGenerator;
+import com.ferreusveritas.dynamictrees.api.event.TransitionSaplingToTreeEvent;
 import com.ferreusveritas.dynamictrees.api.network.MapSignal;
 import com.ferreusveritas.dynamictrees.api.network.NodeInspector;
 import com.ferreusveritas.dynamictrees.api.registry.RegistryEntry;
@@ -114,6 +115,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -1074,30 +1076,40 @@ public class Species extends RegistryEntry<Species> implements Resettable<Specie
         return 0;
     }
 
-    public boolean transitionToTree(World world, BlockPos pos) {
+    public final boolean transitionToTree(World world, BlockPos pos) {
+        Event event = new TransitionSaplingToTreeEvent(this, world, pos);
+        MinecraftForge.EVENT_BUS.post(event);
 
-        //Ensure planting conditions are right
-        Family family = getFamily();
-        if (world.isEmptyBlock(pos.above()) && isAcceptableSoil(world, pos.below(), world.getBlockState(pos.below()))) {
-            // Set to a single branch with 1 radius.
-            family.getBranch().ifPresent(branch -> branch.setRadius(world, pos, family.getPrimaryThickness(), null));
-            // Place a single leaf block on top.
-            world.setBlockAndUpdate(pos.above(), getLeavesProperties().getDynamicLeavesState());
-            // Set to fully fertilized rooty dirt underneath.
-            placeRootyDirtBlock(world, pos.below(), 15);
-
-            if (doesRequireTileEntity(world, pos)) {
-                SpeciesTileEntity speciesTE = DTRegistries.speciesTE.create();
-                world.setBlockEntity(pos.below(), speciesTE);
-                if (speciesTE != null) {
-                    speciesTE.setSpecies(this);
-                }
-            }
-
-            return true;
+        // Transition if event wasn't cancelled and conditions are met.
+        if (!event.isCanceled() && shouldTransitionToTree(world, pos)) {
+            return transitionToTree(world, pos, getFamily());
         }
 
         return false;
+    }
+
+    protected boolean shouldTransitionToTree(World world, BlockPos pos) {
+        return world.isEmptyBlock(pos.above()) &&
+                isAcceptableSoil(world, pos.below(), world.getBlockState(pos.below()));
+    }
+
+    protected boolean transitionToTree(World world, BlockPos pos, Family family) {
+        // Set to a single branch with 1 radius.
+        family.getBranch().ifPresent(branch -> branch.setRadius(world, pos, family.getPrimaryThickness(), null));
+        // Place a single leaf block on top.
+        world.setBlockAndUpdate(pos.above(), getLeavesProperties().getDynamicLeavesState());
+        // Set to fully fertilized rooty dirt underneath.
+        placeRootyDirtBlock(world, pos.below(), 15);
+
+        if (doesRequireTileEntity(world, pos)) {
+            SpeciesTileEntity speciesTE = DTRegistries.speciesTE.create();
+            world.setBlockEntity(pos.below(), speciesTE);
+            if (speciesTE != null) {
+                speciesTE.setSpecies(this);
+            }
+        }
+
+        return true;
     }
 
     private VoxelShape saplingShape = CommonVoxelShapes.SAPLING;

--- a/src/main/java/com/ferreusveritas/dynamictrees/trees/species/PalmSpecies.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/trees/species/PalmSpecies.java
@@ -22,7 +22,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.Biome;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -63,20 +62,16 @@ public class PalmSpecies extends Species {
         return super.postGrow(world, rootPos, treePos, fertility, natural);
     }
 
-    public boolean transitionToTree(World world, BlockPos pos) {
-        //Ensure planting conditions are right
-        Family family = getFamily();
-        if (world.isEmptyBlock(pos.above()) && isAcceptableSoil(world, pos.below(), world.getBlockState(pos.below()))) {
-            family.getBranch().ifPresent(branch ->
-                    // Set to a single branch with 1 radius.
-                    branch.setRadius(world, pos, family.getPrimaryThickness(), null)
-            );
-            world.setBlockAndUpdate(pos.above(), getLeavesProperties().getDynamicLeavesState().setValue(DynamicLeavesBlock.DISTANCE, 4));//Place 2 leaf blocks on top
-            world.setBlockAndUpdate(pos.above(2), getLeavesProperties().getDynamicLeavesState().setValue(DynamicLeavesBlock.DISTANCE, 3));
-            placeRootyDirtBlock(world, pos.below(), 15);//Set to fully fertilized rooty dirt underneath
-            return true;
-        }
-        return false;
+    @Override
+    protected boolean transitionToTree(World world, BlockPos pos, Family family) {
+        family.getBranch().ifPresent(branch ->
+                // Set to a single branch with 1 radius.
+                branch.setRadius(world, pos, family.getPrimaryThickness(), null)
+        );
+        world.setBlockAndUpdate(pos.above(), getLeavesProperties().getDynamicLeavesState().setValue(DynamicLeavesBlock.DISTANCE, 4));//Place 2 leaf blocks on top
+        world.setBlockAndUpdate(pos.above(2), getLeavesProperties().getDynamicLeavesState().setValue(DynamicLeavesBlock.DISTANCE, 3));
+        placeRootyDirtBlock(world, pos.below(), 15);//Set to fully fertilized rooty dirt underneath
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Adds a new event, `TransitionSaplingToTreeEvent`, as requested by @joe-vettek. 

#### Event Info
- Invoked before sapling transition logic
- Cancelable

#### Supporting Changes
- `Species#transitionToTree` split into three methods:
  - `Species#transitionToTree(World, BlockPos)`; the original method. Now invokes the event and then performs transition using other new methods. Made `final` to make incompatibility with this event cause compilation errors. 
  - `Species#shouldTransitionToTree`; called if the event is not cancelled, running the default checks for empty block above and acceptable soil below. 
  - `Species#transitionToTree(World, BlockPos, Family)`; the method that now handles transition logic. Invoked only if the event is not cancelled and `shouldTransitionToTree` returns `true`. 