### PR TITLE
Add a default destroyTime for BlockWithDynamicHardness that isn't zero.

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockWithDynamicHardness.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/blocks/BlockWithDynamicHardness.java
@@ -20,7 +20,7 @@ import net.minecraft.world.level.block.state.properties.Property;
 public abstract class BlockWithDynamicHardness extends Block {
 
     public BlockWithDynamicHardness(Properties properties) {
-        super(properties);
+        super(properties.destroyTime(2.0f));
 
         // Create and fill a new state container.
         final StateDefinition.Builder<Block, BlockState> builder = new StateDefinition.Builder<>(this);


### PR DESCRIPTION
In short - this should not have any effect on the functionality of dynamic trees itself. This sets the vanilla field to a default value of 2.0, rather than zero (which indicates this block breaks instantly). This exists purely for cases where the underlying field is queried by another mod, because a position isn't available.

I ran into this with an issue with one of my mods. While I'm able to fix this for the most part, because Forge does provide a position to `PlayerEvent.BreakSpeed`, it does *not* provide a position to `PlayerEvent.HarvestCheck`, and this is a, in my opinion, harmless change on dynamic tree's part that would avoid the issue all together, in addition to my own fix in https://github.com/alcatrazEscapee/no-tree-punching/commit/7dbdebfd1a48f8e3ac0c22b20decc67acef472e3.