### PR TITLE
add option to specify heightmap type on a per-biome basis in default.…

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/api/worldgen/GroundFinder.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/api/worldgen/GroundFinder.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.levelgen.Heightmap;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +36,7 @@ public interface GroundFinder {
      * @param start the {@link BlockPos} to start from
      * @return the {@link BlockPos} of the first ground block
      */
-    List<BlockPos> findGround(LevelAccessor level, BlockPos start);
+    List<BlockPos> findGround(LevelAccessor level, BlockPos start, Heightmap.Types heightmap);
 
     static void registerGroundFinder(ResourceKey<Level> dimension, GroundFinder groundFinder) {
         GROUND_FINDERS.put(dimension, groundFinder);

--- a/src/main/java/com/ferreusveritas/dynamictrees/resources/loader/BiomePopulatorsResourceLoader.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/resources/loader/BiomePopulatorsResourceLoader.java
@@ -108,6 +108,7 @@ public final class BiomePopulatorsResourceLoader extends AbstractResourceLoader<
                 .register("multipass", JsonObject.class, BiomeDatabase.BaseEntry::setCustomMultipass)
                 .register("blacklist", Boolean.class, BiomeDatabase.BaseEntry::setBlacklisted)
                 .register("forestness", Float.class, BiomeDatabase.BaseEntry::setForestness)
+                .register("heightmap", String.class, BiomeDatabase.BaseEntry::setHeightmap)
                 .registerIfTrueApplier("reset", BiomeDatabase.BaseEntry::reset);
 
         this.caveRootedEntryAppliers

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/BiomeDatabase.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/BiomeDatabase.java
@@ -12,6 +12,7 @@ import com.mojang.serialization.DataResult;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nullable;
@@ -109,6 +110,8 @@ public class BiomeDatabase {
 
         float getForestness();
 
+        String getHeightmap();
+
         Function<Integer, Integer> getMultipass();
 
     }
@@ -122,6 +125,7 @@ public class BiomeDatabase {
         private FeatureCancellation featureCancellation = NoFeatureCancellation.INSTANCE;
         private boolean blacklisted = false;
         private float forestness = 0.0f;
+        private String heightmap = "WORLD_SURFACE_WG";
         private final static Function<Integer, Integer> defaultMultipass = pass -> (pass == 0 ? 0 : -1);
         private Function<Integer, Integer> multipass = defaultMultipass;
 
@@ -245,9 +249,18 @@ public class BiomeDatabase {
             this.forestness = forestness;
         }
 
+        public void setHeightmap(String heightmap) {
+            this.heightmap = heightmap;
+        }
+
         @Override
         public float getForestness() {
             return forestness;
+        }
+
+        @Override
+        public String getHeightmap() {
+            return heightmap;
         }
 
         public void setMultipass(Function<Integer, Integer> multipass) {
@@ -305,6 +318,7 @@ public class BiomeDatabase {
             this.densitySelector = (rnd, nd) -> -1;
             this.chanceSelector = (rnd, spc, rad) -> BiomePropertySelectors.Chance.UNHANDLED;
             this.forestness = 0.0F;
+            this.heightmap = "WORLD_SURFACE_WG";
             this.blacklisted = false;
             this.multipass = defaultMultipass;
         }
@@ -397,12 +411,21 @@ public class BiomeDatabase {
         return getEntry(biome).getForestness();
     }
 
+    public String getHeightmap(Biome biome) {
+        return getEntry(biome).getHeightmap();
+    }
+
     public Function<Integer, Integer> getMultipass(Biome biome) {
         return getEntry(biome).getMultipass();
     }
 
     public BiomeDatabase setForestness(Biome biome, float forestness) {
         getEntry(biome).setForestness((float) Math.max(forestness, DTConfigs.SEED_MIN_FORESTNESS.get()));
+        return this;
+    }
+
+    public BiomeDatabase setHeightmap(Biome biome, String heightmap) {
+        getEntry(biome).setHeightmap(heightmap);
         return this;
     }
 

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/CaveRootedTreeFeature.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/CaveRootedTreeFeature.java
@@ -35,7 +35,7 @@ public class CaveRootedTreeFeature extends DynamicTreeFeature {
             return false;
         }
 
-        List<BlockPos> groundPositions = GroundFinder.getGroundFinder(level.getLevel()).findGround(level, originPos);
+        List<BlockPos> groundPositions = GroundFinder.getGroundFinder(level.getLevel()).findGround(level, originPos, null);
         if (groundPositions.isEmpty()) {
             return false;
         }

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/DynamicTreeFeature.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/DynamicTreeFeature.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
@@ -68,12 +69,14 @@ public class DynamicTreeFeature extends Feature<NoneFeatureConfiguration> {
 
     protected void generateTrees(LevelContext levelContext, BiomeDatabase biomeDatabase, PoissonDisc disc, BlockPos originPos, SafeChunkBounds safeBounds) {
         BlockPos basePos = new BlockPos(disc.x, 0, disc.z);
-        for (BlockPos groundPos : GroundFinder.getGroundFinder(levelContext.level()).findGround(levelContext.accessor(), basePos)) {
+        Biome biome = levelContext.accessor().getBiome(originPos).value();
+        Heightmap.Types heightmap = Heightmap.Types.valueOf(biomeDatabase.getHeightmap(biome));
+        for (BlockPos groundPos : GroundFinder.getGroundFinder(levelContext.level()).findGround(levelContext.accessor(), basePos, heightmap)) {
             BiomeDatabase.EntryReader entry = biomeDatabase.getEntry(levelContext.accessor().getBiome(groundPos).value());
             generateTree(levelContext, entry, disc, originPos, groundPos, safeBounds);
         }
     }
-
+    
     protected GeneratorResult generateTree(LevelContext levelContext, BiomeDatabase.EntryReader biomeEntry, PoissonDisc circle, BlockPos originPos, BlockPos groundPos, SafeChunkBounds safeBounds) {
         if (groundPos == BlockPos.ZERO) {
             return GeneratorResult.NO_GROUND;

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/OverworldGroundFinder.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/OverworldGroundFinder.java
@@ -4,6 +4,7 @@ import com.ferreusveritas.dynamictrees.api.worldgen.GroundFinder;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.levelgen.Heightmap;
 
 import java.util.Collections;
 import java.util.List;
@@ -14,8 +15,12 @@ import java.util.List;
 public final class OverworldGroundFinder implements GroundFinder {
 
     @Override
-    public List<BlockPos> findGround(LevelAccessor level, BlockPos start) {
-        return Collections.singletonList(CoordUtils.findWorldSurface(level, start, true));
+    public List<BlockPos> findGround(LevelAccessor level, BlockPos start, Heightmap.Types heightmap) {
+    	if (heightmap == null) {
+    		return Collections.singletonList(CoordUtils.findWorldSurface(level, start, true));
+    	} else {
+    		return Collections.singletonList(CoordUtils.findWorldSurface(level, start, heightmap));    		
+    	}
     }
 
 }

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/SubterraneanGroundFinder.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/SubterraneanGroundFinder.java
@@ -62,7 +62,7 @@ public class SubterraneanGroundFinder implements GroundFinder {
     }
 
     @Override
-    public List<BlockPos> findGround(LevelAccessor level, BlockPos start) {
+    public List<BlockPos> findGround(LevelAccessor level, BlockPos start, Heightmap.Types heightmap) {
         final ArrayList<Integer> layers = findSubterraneanLayerHeights(level, start);
         if (layers.size() < 1) {
             return NO_LAYERS;


### PR DESCRIPTION
…json

Reasoning: no reason to hard-code Heightmap.Type in ground finder to WORLD_SURFACE or WORLD_SURFACE_WG. For example, generating trees on terralith's skylands biomes requires "OCEAN_FLOOR", but this is not the only application - what if someone wants to generate trees on the ocean floor?

1) adds an entry in BiomePopulatorsResourceLoader and BiomeDatabase for a string "heightmap" to be used in apply section of default.json (defaults to "WORLD_SURFACE_WG", consistent with current behavior)
2) edits findGround in interface GroundFinder to have an additional parameter "Heightmap.Types heightmap"
3) updates the groundfinders (overworld, subterranean) to include this parameter in their calls
4) updates the classes that call findGround to include this parameter in their calls (luckily, Heightmap.Types has a function .valueOf() which takes the string and returns the corresponding Heightmap.Types or null if no match (so can easily call with null if not using)
