### PR TITLE
Fix BiomeDatabase#reset

### DIFF
--- a/src/main/java/com/ferreusveritas/dynamictrees/resources/loader/BiomePopulatorsResourceLoader.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/resources/loader/BiomePopulatorsResourceLoader.java
@@ -86,7 +86,7 @@ public final class BiomePopulatorsResourceLoader extends AbstractResourceLoader<
                 !suppress.getAsJsonPrimitive().getAsBoolean();
     }
 
-    private final JsonPropertyAppliers<BiomeDatabase.BaseEntry> entryAppliers = new JsonPropertyAppliers<>(BiomeDatabase.BaseEntry.class);
+    private final JsonPropertyAppliers<BiomeDatabase.JsonEntry> entryAppliers = new JsonPropertyAppliers<>(BiomeDatabase.JsonEntry.class);
     private final JsonPropertyAppliers<BiomeDatabase.CaveRootedData> caveRootedDataAppliers = new JsonPropertyAppliers<>(BiomeDatabase.CaveRootedData.class);
 
     public BiomePopulatorsResourceLoader() {
@@ -104,7 +104,7 @@ public final class BiomePopulatorsResourceLoader extends AbstractResourceLoader<
                 .register("blacklist", Boolean.class, BiomeDatabase.BaseEntry::setBlacklisted)
                 .register("forestness", Float.class, BiomeDatabase.BaseEntry::setForestness)
                 .register("heightmap", String.class, BiomeDatabase.BaseEntry::setHeightmap)
-                .registerIfTrueApplier("reset", BiomeDatabase.BaseEntry::reset);
+                .register("force", Boolean.class, BiomeDatabase.JsonEntry::setForce);
 
         this.caveRootedDataAppliers
                 .register("generate_on_surface", Boolean.class, BiomeDatabase.CaveRootedData::setGenerateOnSurface)

--- a/src/main/java/com/ferreusveritas/dynamictrees/worldgen/BiomeDatabase.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/worldgen/BiomeDatabase.java
@@ -32,7 +32,7 @@ public class BiomeDatabase {
     private final Map<DTBiomeHolderSet, JsonEntry> jsonEntries = new LinkedHashMap<>();
     private final Map<ResourceLocation, Entry> entries = new HashMap<>();
 
-    public Entry getJsonEntry(DTBiomeHolderSet biomes) {
+    public JsonEntry getJsonEntry(DTBiomeHolderSet biomes) {
         return this.jsonEntries.computeIfAbsent(biomes, k -> new JsonEntry(this));
     }
 
@@ -73,10 +73,7 @@ public class BiomeDatabase {
      * @implNote does not reset cancellers, since they are only applied once on initial load
      */
     public void reset() {
-        this.entries.values().forEach(BaseEntry::reset);
-    }
-
-    public void clear() {
+        this.jsonEntries.clear();
         this.entries.clear();
     }
 
@@ -386,6 +383,7 @@ public class BiomeDatabase {
      * deferred and applied later to a set of biome-specific entries.
      */
     public static class JsonEntry extends Entry {
+        private boolean force = false;
         private boolean changedChanceSelector = false;
         private boolean changedDensitySelector = false;
         private boolean changedSpeciesSelector = false;
@@ -399,12 +397,29 @@ public class BiomeDatabase {
         }
 
         /**
+         * {@return whether this json entry should be forcefully copied and reset any other properties on all declared biomes}
+         * Defaults to false.
+         */
+        public boolean isForce() {
+            return this.force;
+        }
+
+        /**
+         * Sets whether this json entry should be forcefully copied and reset any other properties on all declared biomes.
+         */
+        public void setForce(boolean force) {
+            this.force = force;
+        }
+
+        /**
          * Copies the changed data stored in this JSON entry to the specified {@code other} entry.
          * This copy method does not overwrite properties in {@code other} that were not changed by this JSON entry.
          *
          * @param other the other entry
          */
         public void copyTo(Entry other) {
+            if (this.force)
+                other.reset();
             if (this.changedChanceSelector)
                 other.chanceSelector = this.chanceSelector;
             if (this.changedDensitySelector)


### PR DESCRIPTION
* Add `force` property to biome database JSON entries to reset all biome entries that a JSON entry is applied to before copying the JSON entry properties. Basically, resets the entries of all biomes declared by the entry by forcing the properties to be exactly the same as the entry