### PR TITLE
Add damage type json files

### DIFF
--- a/src/main/resources/data/dynamictrees/damage_type/falling_tree.json
+++ b/src/main/resources/data/dynamictrees/damage_type/falling_tree.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.1,
+  "message_id": "falling_tree",
+  "scaling": "when_caused_by_living_non_player"
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/falling_tree.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/falling_tree.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "mod_id:falling_tree"
+    "dynamictrees:falling_tree"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/damage_type/falling_tree.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/falling_tree.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "mod_id:falling_tree"
+  ]
+}


### PR DESCRIPTION
This fixes the crash that was happening when a player would take damage from a falling tree