### PR TITLE
Fixed a crash with PMMO and DT Addons

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 modName=DynamicTrees
 modId=dynamictrees
-modVersion=1.3.0-BETA6
+modVersion=1.3.0-BETA7
 group=com.ferreusveritas.dynamictrees
 
 mcVersion=1.20.1

--- a/src/localization/resources/assets/dynamictrees/lang/fr_fr.json
+++ b/src/localization/resources/assets/dynamictrees/lang/fr_fr.json
@@ -8,6 +8,10 @@
   "block.dynamictrees.acacia_branch": "Acacia",
   "block.dynamictrees.crimson_branch": "Champignon carmin",
   "block.dynamictrees.warped_branch": "Champignon biscornu",
+  "block.dynamictrees.mangrove_branch": "Palétuvier",
+  "block.dynamictrees.mangrove_roots": "Racines de palétuvier",
+  "block.dynamictrees.cherry_branch": "Cerisier",
+
   "species.dynamictrees.oak": "Chêne",
   "species.dynamictrees.swamp_oak": "Chêne des marais",
   "species.dynamictrees.spruce": "Épicéa",
@@ -23,6 +27,16 @@
   "species.dynamictrees.mega_crimson": "Champignon carmin géant",
   "species.dynamictrees.warped": "Champignon biscornu",
   "species.dynamictrees.mega_warped": "Champignon biscornu géant",
+  "species.dynamictrees.red_mushroom": "Champignon rouge",
+  "species.dynamictrees.brown_mushroom": "Champignon Marron",
+  "species.dynamictrees.cocoa": "Cacao",
+  "species.dynamictrees.oak_undergrowth": "Buisson de chêne",
+  "species.dynamictrees.jungle_undergrowth": "Buisson d'acajou",
+  "species.dynamictrees.mangrove": "Palétuvier",
+  "species.dynamictrees.cherry": "Cerisier",
+  "species.dynamictrees.azalea": "Azalée",
+
+
   "item.dynamictrees.oak_seed": "Gland de chêne",
   "item.dynamictrees.spruce_seed": "Cône d'épicéa",
   "item.dynamictrees.birch_seed": "Graine de bouleau",
@@ -32,6 +46,11 @@
   "item.dynamictrees.apple_oak_seed": "Pépin de pomme",
   "item.dynamictrees.crimson_seed": "Chapeau de champignon carmin",
   "item.dynamictrees.warped_seed": "Chapeau de champignon biscornu",
+  "item.dynamictrees.mangrove_seed": "Propagule de palétuvier",
+  "item.dynamictrees.cocoa_seed": "Graine de cacao",
+  "item.dynamictrees.cherry_seed": "Noyau de cerisier",
+  "item.dynamictrees.azalea_seed": "Graine d'azalée",
+
   "item.dynamictrees.dendro_potion.biochar": "Potion bio-charbon de base",
   "item.dynamictrees.dendro_potion.depletion": "Potion d'épuisement",
   "item.dynamictrees.dendro_potion.gigas": "Potion de gigantisme",
@@ -41,9 +60,11 @@
   "item.dynamictrees.dendro_potion.transform": "Potion de transformation",
   "item.dynamictrees.dendro_potion.harvest": "Potion de récolte",
   "item.dynamictrees.dendro_potion.denuding": "Potion de déboisement",
+
   "item.dynamictrees.dirt_bucket": "Seau de terre",
   "item.dynamictrees.staff": "Bâton des bois",
   "block.dynamictrees.potted_sapling": "Pousse en pot",
+
   "chat.registry_name": "Nom de registre: %s",
   "tooltip.dynamictrees.species": "Espèce: %s",
   "tooltip.dynamictrees.fertility": "Fertilité: %s",
@@ -79,5 +100,8 @@
   "potion.harvest.description": "Accélère la production de fruits",
   "potion.denuding.description": "Enlève toute l'écorce et les feuilles d'un arbre",
   "death.attack.falling_tree": "%1$s a été écrasé par un arbre qui tombe",
-  "block.dynamictrees.rooty_water": "Racines aquatiques"
+  "block.dynamictrees.rooty_water": "Racines aquatiques",
+
+  "block.minecraft.mangrove_propagule": "Propagule de palétuvier",
+  "block.minecraft.potted_mangrove_propagule": "Propagule de palétuvier en pot"
 }

--- a/src/main/java/com/ferreusveritas/dynamictrees/block/branch/BasicBranchBlock.java
+++ b/src/main/java/com/ferreusveritas/dynamictrees/block/branch/BasicBranchBlock.java
@@ -212,6 +212,10 @@ public class BasicBranchBlock extends BranchBlock implements SimpleWaterloggedBl
 
     @Override
     public float getHardness(BlockState state, BlockGetter level, BlockPos pos) {
+        if (level == null) {
+            return 1.0f;
+        }
+
         final int radius = this.getRadius(level.getBlockState(pos));
         final float hardness = this.getFamily().getPrimitiveLog().orElse(Blocks.AIR).defaultBlockState()
                 .getDestroySpeed(level, pos) * (radius * radius) / 64.0f * 8.0f;


### PR DESCRIPTION
Crash with Project MMO, only with Addons like Slayer's Beasts and Nature's Spirit. Nothing should have changed in the gameplay, it just returns something instead of "null".

https://github.com/InvictusSlayer/DynamicTrees-Slayers-Beasts/issues/1

And Updated French translation, because why not.