### PR TITLE
Fix Sodium crash on branches/roots (null material NPE)

### DIFF
--- a/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/BasicBranchBlockBakedModel.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/BasicBranchBlockBakedModel.java
@@ -5,6 +5,9 @@ import com.google.common.collect.Maps;
 import net.fabricmc.fabric.api.renderer.v1.mesh.*;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.block.model.BlockElementFace;
@@ -200,7 +203,7 @@ public class BasicBranchBlockBakedModel implements BakedModel, FabricBakedModel 
                 }
                 for (BakedQuad quad : quads) {
                     if (quad.getDirection() == face) {
-                        emitQuad(emitter, quad, face);
+                        emitQuad(emitter, quad, face, context);
                     }
                 }
             }
@@ -214,7 +217,7 @@ public class BasicBranchBlockBakedModel implements BakedModel, FabricBakedModel 
                         if (sleeveQuads != null) {
                             for (BakedQuad quad : sleeveQuads) {
                                 if (quad.getDirection() == face) {
-                                    emitQuad(emitter, quad, face);
+                                    emitQuad(emitter, quad, face, context);
                                 }
                             }
                         }
@@ -224,8 +227,17 @@ public class BasicBranchBlockBakedModel implements BakedModel, FabricBakedModel 
         }
     }
 
-    protected void emitQuad(QuadEmitter emitter, BakedQuad quad, Direction cullFace) {
-        emitter.fromVanilla(quad, null, cullFace);
+    protected void emitQuad(QuadEmitter emitter, BakedQuad quad, Direction cullFace, RenderContext context) {
+        var renderer = RendererAccess.INSTANCE.getRenderer();
+
+        MaterialFinder finder = renderer.materialFinder();
+
+        finder.disableAo(0, true);
+        finder.disableDiffuse(0, true);
+
+        RenderMaterial material = finder.find();
+
+        emitter.fromVanilla(quad, material, cullFace);
         emitter.emit();
     }
 

--- a/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/BasicRootsBlockBakedModel.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/BasicRootsBlockBakedModel.java
@@ -85,7 +85,6 @@ public class BasicRootsBlockBakedModel extends BasicBranchBlockBakedModel {
         return super.getRadius(blockState);
     }
 
-    @Override
     protected void emitQuad(QuadEmitter emitter, BakedQuad quad, Direction cullFace) {
         emitter.fromVanilla(quad, null, null);
         emitter.emit();

--- a/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/SurfaceRootBlockBakedModel.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/SurfaceRootBlockBakedModel.java
@@ -7,6 +7,9 @@ import com.google.common.collect.Maps;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.block.model.BlockElementFace;
@@ -254,7 +257,15 @@ public class SurfaceRootBlockBakedModel implements BakedModel, FabricBakedModel 
                 if (coreQuads != null) {
                     for (BakedQuad quad : coreQuads) {
                         if (quad.getDirection() == face) {
-                            emitter.fromVanilla(quad, null, null);
+                            var renderer = RendererAccess.INSTANCE.getRenderer();
+                            MaterialFinder finder = renderer.materialFinder();
+
+                            finder.disableAo(0, true);
+                            finder.disableDiffuse(0, true);
+
+                            RenderMaterial material = finder.find();
+
+                            emitter.fromVanilla(quad, material, null);
                             emitter.emit();
                         }
                     }
@@ -269,7 +280,15 @@ public class SurfaceRootBlockBakedModel implements BakedModel, FabricBakedModel 
                         if (isGrounded && sleevesQuads[idx][connRadius - 1] != null) {
                             for (BakedQuad quad : sleevesQuads[idx][connRadius - 1]) {
                                 if (quad.getDirection() == face) {
-                                    emitter.fromVanilla(quad, null, null);
+                                    var renderer = RendererAccess.INSTANCE.getRenderer();
+                                    MaterialFinder finder = renderer.materialFinder();
+
+                                    finder.disableAo(0, true);
+                                    finder.disableDiffuse(0, true);
+
+                                    RenderMaterial material = finder.find();
+
+                                    emitter.fromVanilla(quad, material, null);
                                     emitter.emit();
                                 }
                             }
@@ -277,7 +296,15 @@ public class SurfaceRootBlockBakedModel implements BakedModel, FabricBakedModel 
                         if (connectionLevels[idx] == RootConnections.ConnectionLevel.HIGH && vertsQuads[idx][connRadius - 1] != null) {
                             for (BakedQuad quad : vertsQuads[idx][connRadius - 1]) {
                                 if (quad.getDirection() == face) {
-                                    emitter.fromVanilla(quad, null, null);
+                                    var renderer = RendererAccess.INSTANCE.getRenderer();
+                                    MaterialFinder finder = renderer.materialFinder();
+
+                                    finder.disableAo(0, true);
+                                    finder.disableDiffuse(0, true);
+
+                                    RenderMaterial material = finder.find();
+
+                                    emitter.fromVanilla(quad, material, null);
                                     emitter.emit();
                                 }
                             }

--- a/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/ThickBranchBlockBakedModel.java
+++ b/fabric/src/main/java/com/dtteam/dynamictrees/model/baked/ThickBranchBlockBakedModel.java
@@ -6,6 +6,9 @@ import com.dtteam.dynamictrees.utility.CoordUtils;
 import com.dtteam.dynamictrees.utility.CoordUtils.Surround;
 import com.google.common.collect.Maps;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.fabricmc.fabric.api.renderer.v1.material.MaterialFinder;
+import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.block.model.BlockElementFace;
@@ -196,12 +199,18 @@ public class ThickBranchBlockBakedModel extends BasicBranchBlockBakedModel {
         int radiusIndex = coreRadius - 9;
         if (radiusIndex < 0 || radiusIndex >= trunksBarkQuads.length) return;
 
+        var renderer = RendererAccess.INSTANCE.getRenderer();
+        MaterialFinder finder = renderer.materialFinder();
+        finder.disableAo(0, true);
+        finder.disableDiffuse(0, true);
+        RenderMaterial material = finder.find();
+
         for (Direction face : Direction.values()) {
             List<BakedQuad> barkQuads = trunksBarkQuads[radiusIndex];
             if (barkQuads != null) {
                 for (BakedQuad quad : barkQuads) {
                     if (quad.getDirection() == face) {
-                        emitter.fromVanilla(quad, null, face);
+                        emitter.fromVanilla(quad, material, face);
                         emitter.emit();
                     }
                 }
@@ -213,7 +222,7 @@ public class ThickBranchBlockBakedModel extends BasicBranchBlockBakedModel {
                     if (ringQuads != null) {
                         for (BakedQuad quad : ringQuads) {
                             if (quad.getDirection() == face) {
-                                emitter.fromVanilla(quad, null, face);
+                                emitter.fromVanilla(quad, material, face);
                                 emitter.emit();
                             }
                         }
@@ -223,7 +232,7 @@ public class ThickBranchBlockBakedModel extends BasicBranchBlockBakedModel {
                     if (topBarkQuads != null) {
                         for (BakedQuad quad : topBarkQuads) {
                             if (quad.getDirection() == face) {
-                                emitter.fromVanilla(quad, null, face);
+                                emitter.fromVanilla(quad, material, face);
                                 emitter.emit();
                             }
                         }


### PR DESCRIPTION
Quick patch to stop Sodium from crashing with NPE when building chunk meshes for branches, thick branches and surface roots.
#1135 

Replaced the null material in `fromVanilla` calls with a real `RenderMaterial` created from `RendererAccess.INSTANCE.getRenderer().materialFinder()`.  
Disabled AO and diffuse on sprite 0 so branches don't get weird dark corners.

Tested in a jungle biome that was previously crashing - thin branches, thick ones (radius 13+), and surface roots all load without issues now.  
Didn't do super heavy testing across every tree type or edge case, but the crash is gone and nothing looks obviously broken.

Please feel free to tweak/improve/revert the shading defaults if needed.